### PR TITLE
fix: Verify Atlas functionality in CI

### DIFF
--- a/.github/workflows/check-integration.yml
+++ b/.github/workflows/check-integration.yml
@@ -11,6 +11,7 @@ on:
       - "db/**"
       - "mise.toml"
       - "mise.lock"
+      - "mise/tasks/integration-test"
       - ".github/workflows/check-integration.yml"
   pull_request:
     paths:
@@ -20,6 +21,7 @@ on:
       - "db/**"
       - "mise.toml"
       - "mise.lock"
+      - "mise/tasks/integration-test"
       - ".github/workflows/check-integration.yml"
 
 concurrency:

--- a/.github/workflows/check-integration.yml
+++ b/.github/workflows/check-integration.yml
@@ -1,0 +1,63 @@
+name: Check integration
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "app/*/src/**"
+      - "app/Cargo.toml"
+      - "app/Cargo.lock"
+      - "db/**"
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/check-integration.yml"
+  pull_request:
+    paths:
+      - "app/*/src/**"
+      - "app/Cargo.toml"
+      - "app/Cargo.lock"
+      - "db/**"
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/check-integration.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: cicd-sensor
+        uses: cicd-sensor/cicd-sensor-action@2b76335ff1c2dd298e983961f7a200d3fe9076c2 # v0.0.36
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: ""
+
+      - name: Install mise and setup
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          install: true
+          install_args: "atlas github:k1LoW/runn"
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          MISE_LOCKED: "1"
+
+      - name: Check
+        run: mise run integration-test

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -3,13 +3,13 @@ name: Check Rust
 on:
   push:
     paths:
-      - "app/src/**"
+      - "app/*/src/**"
       - "app/Cargo.toml"
       - "app/Cargo.lock"
       - ".github/workflows/check-rust.yml"
   pull_request:
     paths:
-      - "app/src/**"
+      - "app/*/src/**"
       - "app/Cargo.toml"
       - "app/Cargo.lock"
       - ".github/workflows/check-rust.yml"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,22 +6,26 @@ on:
       - main
     paths:
       - "app/*/src/**"
+      - "app/*/Cargo.toml"
       - "app/Cargo.toml"
       - "app/Cargo.lock"
       - "db/**"
       - "mise.toml"
       - "mise.lock"
       - "mise/tasks/integration-test"
+      - "tests/runn/**"
       - ".github/workflows/integration-test.yml"
   pull_request:
     paths:
       - "app/*/src/**"
+      - "app/*/Cargo.toml"
       - "app/Cargo.toml"
       - "app/Cargo.lock"
       - "db/**"
       - "mise.toml"
       - "mise.lock"
       - "mise/tasks/integration-test"
+      - "tests/runn/**"
       - ".github/workflows/integration-test.yml"
 
 concurrency:
@@ -33,6 +37,7 @@ permissions: {}
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     permissions:
       contents: read

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,4 +1,4 @@
-name: Check integration
+name: Integration test
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
       - "mise.toml"
       - "mise.lock"
       - "mise/tasks/integration-test"
-      - ".github/workflows/check-integration.yml"
+      - ".github/workflows/integration-test.yml"
   pull_request:
     paths:
       - "app/*/src/**"
@@ -22,7 +22,7 @@ on:
       - "mise.toml"
       - "mise.lock"
       - "mise/tasks/integration-test"
-      - ".github/workflows/check-integration.yml"
+      - ".github/workflows/integration-test.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,11 @@ This file provides guidance to AI coding agents when working with code in this r
 
 A Rust web application template built with [Actix Web](https://actix.rs) and the Onion architecture.
 The application code lives in the `app/` directory.
+`app/` is a Cargo workspace with each crate in its own subdirectory
+(`app/server/src`, `app/domain/src`, etc.) — there is no `app/src/`.
+When writing GitHub Actions `paths:` filters for Rust source changes, use
+`app/*/src/**`, not `app/src/**` (the latter never matches anything and
+silently disables the trigger).
 Development tooling (linting, formatting, spell checking, git hooks) is managed via [mise](https://mise.jdx.dev).
 
 ## Development Rules

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -1371,14 +1371,12 @@ dependencies = [
  "js-sys",
  "p256",
  "p384",
- "pem",
  "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
  "sha2",
  "signature",
- "simple_asn1",
 ]
 
 [[package]]
@@ -1542,16 +1540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,16 +1659,6 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
 ]
 
 [[package]]
@@ -2167,18 +2145,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
-]
 
 [[package]]
 name = "slab"

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -290,6 +290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +569,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +597,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -677,12 +722,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -731,6 +835,22 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -884,6 +1004,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -921,6 +1042,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1233,11 +1365,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
  "signature",
  "simple_asn1",
 ]
@@ -1471,6 +1610,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +1934,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1989,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "seeder"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -17,7 +17,7 @@ actix-web = "4"
 argon2 = "0.5"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-jsonwebtoken = "10"
+jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto", "use_pem"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -17,7 +17,7 @@ actix-web = "4"
 argon2 = "0.5"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto", "use_pem"] }
+jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/mise.lock
+++ b/mise.lock
@@ -47,29 +47,36 @@ url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/3849249
 provenance = "github-attestations"
 
 [[tools.atlas]]
-version = "1.2.3"
+version = "1.2.0"
 backend = "aqua:ariga/atlas"
 
 [tools.atlas."platforms.linux-arm64"]
-url = "https://release.ariga.io/atlas/atlas-linux-arm64-1.2.3"
+checksum = "sha256:b76308f558d50d006add507f3ab86afc1147644519dd327f7f5fac6d02d4f595"
+url = "https://release.ariga.io/atlas/atlas-linux-arm64-v1.2.0"
 
 [tools.atlas."platforms.linux-arm64-musl"]
-url = "https://release.ariga.io/atlas/atlas-linux-arm64-1.2.3"
+checksum = "sha256:b76308f558d50d006add507f3ab86afc1147644519dd327f7f5fac6d02d4f595"
+url = "https://release.ariga.io/atlas/atlas-linux-arm64-v1.2.0"
 
 [tools.atlas."platforms.linux-x64"]
-url = "https://release.ariga.io/atlas/atlas-linux-amd64-1.2.3"
+checksum = "sha256:c12b889e3349f0e5610aec32fe327e5a6911a0e472754a0c381c30c7c0630e88"
+url = "https://release.ariga.io/atlas/atlas-linux-amd64-v1.2.0"
 
 [tools.atlas."platforms.linux-x64-musl"]
-url = "https://release.ariga.io/atlas/atlas-linux-amd64-1.2.3"
+checksum = "sha256:c12b889e3349f0e5610aec32fe327e5a6911a0e472754a0c381c30c7c0630e88"
+url = "https://release.ariga.io/atlas/atlas-linux-amd64-v1.2.0"
 
 [tools.atlas."platforms.macos-arm64"]
-url = "https://release.ariga.io/atlas/atlas-darwin-arm64-1.2.3"
+checksum = "sha256:c0d8443a603991c337341a303abf3812cb9f12d74d0ec0d585245735f18c1224"
+url = "https://release.ariga.io/atlas/atlas-darwin-arm64-v1.2.0"
 
 [tools.atlas."platforms.macos-x64"]
-url = "https://release.ariga.io/atlas/atlas-darwin-amd64-1.2.3"
+checksum = "sha256:47f98e6f0d6a203f6c84e643f1ad99519fa8c2b5b59c177af3c449bd3ae0bb5a"
+url = "https://release.ariga.io/atlas/atlas-darwin-amd64-v1.2.0"
 
 [tools.atlas."platforms.windows-x64"]
-url = "https://release.ariga.io/atlas/atlas-windows-amd64-1.2.3.exe"
+checksum = "sha256:5dbf3e7ec63306bce97904c6ad6ecb82633f0299b98c73987607204d551a80b1"
+url = "https://release.ariga.io/atlas/atlas-windows-amd64-v1.2.0.exe"
 
 [[tools.betterleaks]]
 version = "v1.6.1"

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ minimum_release_age = "3d"
 node = "26"
 
 # Database
-atlas = "1.2.3"
+atlas = "1.2.0"
 "github:quarylabs/sqruff" = "0.38"
 
 # Testing
@@ -217,6 +217,7 @@ alias = "sc"
 description = "Seed database for the specified environment (ENV=local)"
 run = "ENV=\"${ENV:-local}\" cargo run --bin seeder"
 dir = "{{vars.app_dir}}"
+
 # Secrets
 [tasks.secret-check]
 description = "Check staged files for leaked secrets"

--- a/mise.toml
+++ b/mise.toml
@@ -145,13 +145,13 @@ dir = "{{vars.app_dir}}"
 
 [tasks.rs-run]
 description = "Run Rust application"
-run = "cargo run"
+run = "cargo run --bin server"
 alias = "rr"
 dir = "{{vars.app_dir}}"
 
 [tasks.rs-watch]
 description = "Watch for file changes and reload Rust application"
-run = "watchexec --exts rs,toml --restart -- cargo run"
+run = "watchexec --exts rs,toml --restart -- cargo run --bin server"
 alias = "rw"
 dir = "{{vars.app_dir}}"
 

--- a/mise/tasks/dev
+++ b/mise/tasks/dev
@@ -6,4 +6,4 @@ set -euo pipefail
 trap 'docker compose stop db' EXIT
 
 docker compose up db -d --wait
-cd app && watchexec --exts rs,toml --restart -- cargo run
+cd app && watchexec --exts rs,toml --restart -- cargo run --bin server

--- a/mise/tasks/integration-test
+++ b/mise/tasks/integration-test
@@ -23,7 +23,7 @@ docker compose exec -T db psql -U postgres app_test -c "TRUNCATE TABLE users CAS
 echo
 
 echo "Starting server..."
-(cd app && DATABASE_URL="${TEST_DATABASE_URL}" JWT_SECRET="${JWT_SECRET:-test-secret-for-integration-testing}" cargo run) &
+(cd app && DATABASE_URL="${TEST_DATABASE_URL}" JWT_SECRET="${JWT_SECRET:-test-secret-for-integration-testing}" cargo run --bin server) &
 SERVER_PID=$!
 echo
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Adds a CI workflow that actually exercises Atlas (`atlas schema apply`) so a PR that only bumps the Atlas version can no longer go green without verifying Atlas still works, plus the underlying bugs uncovered while getting that workflow to succeed.

## Reason for change

Closes #76: a PR bumping the Atlas version (e.g. #74) got all CI checks green even though `mise run integration-test` — the only task that actually runs Atlas — was never wired into any workflow. Investigation also found that PR #74 had pinned `atlas` to `1.2.3`, whose `mise.lock` entry is broken (aqua-registry URL missing a `v` prefix, no checksum), making it un-fetchable; this went unnoticed for the same reason.

Wiring up the new workflow surfaced two more real, previously-undetected bugs:

- `cargo run` fails outright in this workspace (two binaries: `server`, `seeder`) without `--bin server`.
- The server panics on every `/auth/login` request: `jsonwebtoken`'s default features don't include a crypto backend, so HS256 signing had no `CryptoProvider` installed.

Both would have broken any integration test the moment one existed, so they're fixed as part of getting this workflow to succeed.

## Changes

- `mise.toml`, `mise.lock`: revert `atlas` from the broken `1.2.3` pin back to `1.2.0`, a real fetchable version (with correct checksums/URLs).
- `mise.toml` (`rs-run`, `rs-watch`), `mise/tasks/dev`, `mise/tasks/integration-test`: disambiguate `cargo run` with `--bin server`.
- `app/Cargo.toml`, `app/Cargo.lock`: enable the `jsonwebtoken` `rust_crypto` feature to fix the `/auth/login` panic; dropped the unused `use_pem` feature.
- `.github/workflows/check-integration.yml` (new): runs `mise run integration-test` (Postgres via docker compose, `atlas schema apply`, boots the server, `runn` HTTP tests) on changes to `app/*/src/**`, `app/Cargo.{toml,lock}`, `db/**`, `mise.toml`/`mise.lock`, `mise/tasks/integration-test`.
- `.github/workflows/check-rust.yml`: fix `paths: "app/src/**"`, which never matched this workspace's actual `app/*/src/**` layout — `check-rust.yml` had never triggered on Rust source changes.

## Notes

- Verified locally end-to-end (`mise run integration-test`, 3/3 `runn` scenarios succeeding) before and after each fix.
- No new GitHub Secrets needed; all required env vars are already non-secret local defaults in `mise.toml`'s `[env]`.
- `rust_crypto` transitively pulls in the `rsa` crate (RUSTSEC-2023-0071, timing side-channel); not exploitable here since only HS256/HMAC signing is used, and `jsonwebtoken` doesn't offer a narrower feature that excludes it.
