### PR TITLE
docs: Add Claude rules for development, architecture and testing

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -19,19 +19,21 @@ layer lives in its own crate under `app/<layer>/src`.
   Postgres-backed `UserRepository` implementation). Depends only on `domain`.
 - `presentation` — Actix Web HTTP handlers; maps requests/responses to
   `use_case` calls. Depends on `domain`, `use_case`, and `container`.
-- `container` — dependency injection: wires concrete `infrastructure`
-  implementations to the trait objects `presentation`/`use_case` consume.
-  Depends only on `domain`.
-- `server` — composition root: builds the `container`, starts Actix Web, wires
-  middleware. Depends on every other crate.
+- `container` — holds the `domain` trait objects (e.g. `Arc<dyn UserRepository>`)
+  that `presentation`/`use_case` consume. Depends only on `domain`; it does not
+  know about `infrastructure`.
+- `server` — composition root: picks the concrete `infrastructure`
+  implementations, constructs the `container` with them, starts Actix Web, and
+  wires middleware. Depends on every other crate.
 
 ## Dependency Rule
 
 - A crate may only depend on crates strictly inside it (closer to `domain`):
-  `domain` ← `use_case` / `infrastructure` ← `presentation` / `container` ← `server`.
+  `domain` ← `use_case` / `infrastructure` / `container` ← `presentation` ← `server`.
 - `domain` must never depend on any other layer.
-- `use_case` and `infrastructure` must not depend on each other — both depend
-  only on `domain`, and are connected through `container`/`server`.
+- `use_case`, `infrastructure`, and `container` must not depend on each
+  other — all three depend only on `domain`, and are connected in `server`,
+  which is the only crate that references concrete `infrastructure` types.
 - New cross-layer trait implementations belong in `infrastructure`; new
   application logic belongs in `use_case`; new business rules and types belong
   in `domain`.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,37 @@
+---
+name: architecture
+description: Onion architecture layers and dependency rules for the app/ workspace
+---
+
+# Architecture
+
+This project follows the Onion architecture. `app/` is a Cargo workspace; each
+layer lives in its own crate under `app/<layer>/src`.
+
+## Layers and Responsibilities
+
+- `domain` — entities, value objects, domain errors, and repository trait
+  definitions (e.g. `UserRepository` in `domain/src/user.rs`). No dependency
+  on any other layer.
+- `use_case` — application business logic (e.g. `login`, `create_user`,
+  `get_user`). Depends only on `domain`.
+- `infrastructure` — concrete adapters to external systems (e.g. the
+  Postgres-backed `UserRepository` implementation). Depends only on `domain`.
+- `presentation` — Actix Web HTTP handlers; maps requests/responses to
+  `use_case` calls. Depends on `domain`, `use_case`, and `container`.
+- `container` — dependency injection: wires concrete `infrastructure`
+  implementations to the trait objects `presentation`/`use_case` consume.
+  Depends only on `domain`.
+- `server` — composition root: builds the `container`, starts Actix Web, wires
+  middleware. Depends on every other crate.
+
+## Dependency Rule
+
+- A crate may only depend on crates strictly inside it (closer to `domain`):
+  `domain` ← `use_case` / `infrastructure` ← `presentation` / `container` ← `server`.
+- `domain` must never depend on any other layer.
+- `use_case` and `infrastructure` must not depend on each other — both depend
+  only on `domain`, and are connected through `container`/`server`.
+- New cross-layer trait implementations belong in `infrastructure`; new
+  application logic belongs in `use_case`; new business rules and types belong
+  in `domain`.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -20,16 +20,20 @@ layer lives in its own crate under `app/<layer>/src`.
 - `presentation` — Actix Web HTTP handlers; maps requests/responses to
   `use_case` calls. Depends on `domain`, `use_case`, and `container`.
 - `container` — holds the `domain` trait objects (e.g. `Arc<dyn UserRepository>`)
-  that `presentation`/`use_case` consume. Depends only on `domain`; it does not
-  know about `infrastructure`.
+  that `presentation` consumes to wire them into use cases. Depends only on
+  `domain`; it does not know about `infrastructure`. `use_case` itself never
+  depends on `container` — it receives domain abstractions directly through
+  its own function signatures.
 - `server` — composition root: picks the concrete `infrastructure`
   implementations, constructs the `container` with them, starts Actix Web, and
   wires middleware. Depends on every other crate.
 
 ## Dependency Rule
 
-- A crate may only depend on crates strictly inside it (closer to `domain`):
-  `domain` ← `use_case` / `infrastructure` / `container` ← `presentation` ← `server`.
+- Allowed dependency edges:
+  - `use_case`, `infrastructure`, `container` → `domain`
+  - `presentation` → `domain`, `use_case`, `container`
+  - `server` → `domain`, `use_case`, `infrastructure`, `presentation`, `container`
 - `domain` must never depend on any other layer.
 - `use_case`, `infrastructure`, and `container` must not depend on each
   other — all three depend only on `domain`, and are connected in `server`,

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -1,0 +1,35 @@
+---
+name: development
+description: mise task usage rules for this repository
+---
+
+# Development
+
+## Use mise Tasks — Required, Not Optional
+
+- Never invoke the underlying tools directly (`cargo`, `markdownlint-cli2`, `sqruff`, `atlas`, `docker compose`, etc.). Always run the equivalent `mise run <task>` command instead.
+- Before running any command that isn't in the list below, check for an existing task first (`mise tasks`) — tasks are defined either in `mise.toml` or as files under `mise/tasks/`.
+- If no task exists for what you need, ask the user before running the raw command — do not silently fall back to it.
+
+Key tasks:
+
+- `mise run setup` — first-time setup (installs tools and git hooks)
+- `mise run rs-run` — run the application
+- `mise run rs-fix` — auto-fix Rust code (clippy + fmt)
+- `mise run rs-check` — check Rust code (clippy + fmt + tests)
+
+## Fix and Check After Editing Files
+
+After editing any file, run:
+
+```bash
+mise run fix
+mise run check
+```
+
+For Rust files specifically:
+
+```bash
+mise run rs-fix
+mise run rs-check
+```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,34 @@
+---
+name: testing
+description: Unit vs integration test classification and where to write each
+---
+
+# Testing
+
+This project uses two test types. Pick the type based on what you're
+verifying, not on convenience.
+
+## Unit Tests
+
+- Location: `#[cfg(test)] mod tests` blocks co-located with the code under
+  test (e.g. `app/use_case/src/login.rs`).
+- Use for: pure logic that doesn't require a running server or database —
+  input validation, domain rules, use case branching.
+- Run via `mise run rs-check` (`cargo test`).
+
+## Integration Tests
+
+- Location: `tests/runn/*.yml`, using the [runn](https://github.com/k1LoW/runn)
+  framework.
+- Use for: end-to-end behavior of API endpoints over HTTP, against a running
+  server and real database — request/response shape, auth flows, status
+  codes.
+- Run via `mise run integration-test`.
+
+## Choosing Between Them
+
+- If the behavior can be tested without an HTTP request or a database
+  connection, write a unit test.
+- If the behavior only manifests through the full request/response cycle
+  (routing, middleware, serialization, DB round-trip), write a `runn`
+  integration test instead of trying to unit-test it in isolation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,31 +22,6 @@ When writing GitHub Actions `paths:` filters for Rust source changes, use
 silently disables the trigger).
 Development tooling (linting, formatting, spell checking, git hooks) is managed via [mise](https://mise.jdx.dev).
 
-## Development Rules
-
-### Use mise Tasks
-
-Prefer `mise run <task>` over running underlying tools directly.
-
-Key tasks:
-
-- `mise run setup` — first-time setup (installs tools and git hooks)
-- `mise run rs-run` — run the application
-- `mise run rs-fix` — auto-fix Rust code (clippy + fmt)
-- `mise run rs-check` — check Rust code (clippy + fmt + tests)
-
-### Fix and Check After Editing Files
-
-After editing any file, run the following to auto-fix and verify:
-
-```bash
-mise run fix
-mise run check
-```
-
-For Rust files specifically:
-
-```bash
-mise run rs-fix
-mise run rs-check
-```
+See `.claude/rules/development.md`, `.claude/rules/architecture.md`, and
+`.claude/rules/testing.md` for development workflow, architecture, and
+testing rules.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add `.claude/rules/development.md`, `.claude/rules/architecture.md`, and
`.claude/rules/testing.md`, and slim `AGENTS.md` down to point at them.

## Reason for change

Closes #77. AI coding agents need explicit guidance on Onion architecture
layer responsibilities/dependency rules and on unit vs. integration test
classification, in addition to the existing mise-task guidance — and the
mise-task guidance itself needed stronger wording since agents kept
falling back to raw commands (`cargo build`, etc.) instead of `mise run`.

## Changes

- `.claude/rules/development.md` — mise task usage, now phrased as a hard
  requirement rather than a preference
- `.claude/rules/architecture.md` — Onion architecture layer responsibilities
  and dependency rules (`domain` ← `use_case`/`infrastructure`/`container` ←
  `presentation` ← `server`)
- `.claude/rules/testing.md` — unit test vs. `runn`-based integration test
  classification and when to use each
- `AGENTS.md` — replaced the inline "Development Rules" section with a
  pointer to the three new rule files

## Notes

Layer dependencies and test classification were confirmed against the
current codebase (crate `Cargo.toml` dependencies, existing test files).