### PR TITLE
ci: Add coverage measurement using cargo-llvm-cov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
       - "app/Cargo.toml"
       - "app/Cargo.lock"
       - "mise.toml"
+      - "mise.lock"
       - ".github/workflows/coverage.yml"
   pull_request:
     paths:
@@ -14,6 +15,7 @@ on:
       - "app/Cargo.toml"
       - "app/Cargo.lock"
       - "mise.toml"
+      - "mise.lock"
       - ".github/workflows/coverage.yml"
 
 concurrency:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,71 @@
+name: Coverage
+
+on:
+  push:
+    paths:
+      - "app/*/src/**"
+      - "app/Cargo.toml"
+      - "app/Cargo.lock"
+      - "mise.toml"
+      - ".github/workflows/coverage.yml"
+  pull_request:
+    paths:
+      - "app/*/src/**"
+      - "app/Cargo.toml"
+      - "app/Cargo.lock"
+      - "mise.toml"
+      - ".github/workflows/coverage.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          components: llvm-tools
+          rustflags: ""
+
+      - name: Install mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Measure coverage
+        run: mise run rs-coverage
+
+      - name: Publish coverage to Job Summary
+        run: |
+          {
+            echo "## Coverage"
+            echo '```'
+            cat app/coverage-summary.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Warn on low coverage
+        run: |
+          percent=$(jq '.data[0].totals.lines.percent' app/coverage.json)
+          echo "Line coverage: ${percent}%"
+          if awk -v p="$percent" 'BEGIN { exit !(p < 90) }'; then
+            echo "::warning::Line coverage ${percent}% is below the 90% threshold"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 app/target/
+app/coverage.json
+app/coverage-summary.txt

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ mise run db-apply
 | `mise run rs-watch` | `mise run rw` | Run with hot reload (watchexec) |
 | `mise run rs-fix` | `mise run rf` | Fix Rust code (clippy + fmt) |
 | `mise run rs-check` | `mise run rc` | Check Rust code |
+| `mise run rs-coverage` | | Measure test coverage |
 | `mise run rs-build` | | Build the application |
 | `mise run rs-build-release` | | Build in release mode |
 | `mise run rs-clean` | | Clean build artifacts |

--- a/docs/workflows/COVERAGE.md
+++ b/docs/workflows/COVERAGE.md
@@ -35,7 +35,7 @@ Both files are gitignored.
 `cargo-llvm-cov` needs the `llvm-tools` rustup component. Locally:
 
 ```bash
-rustup component add llvm-tools-preview
+rustup component add llvm-tools
 ```
 
 CI installs it automatically via `actions-rust-lang/setup-rust-toolchain`'s `components: llvm-tools`.

--- a/docs/workflows/COVERAGE.md
+++ b/docs/workflows/COVERAGE.md
@@ -1,0 +1,58 @@
+# Coverage Guideline
+
+This document explains how test coverage is measured and reported in this project.
+
+## Tooling
+
+- [`cargo-llvm-cov`](https://crates.io/crates/cargo-llvm-cov) measures line, region, and
+  branch coverage using LLVM source-based code coverage.
+- Pinned in `mise.toml`'s `[tools]`; installed via `mise install`.
+
+## Policy
+
+- Report only — coverage never fails CI.
+- Coverage is always displayed in the workflow's Job Summary.
+- `::warning::` is emitted when line coverage drops below **90%**.
+- No external service integration (e.g. Codecov); everything is self-contained.
+
+## Running Locally
+
+```bash
+mise run rs-coverage
+```
+
+This runs `cargo llvm-cov --workspace --all-features` and writes:
+
+| File | Purpose |
+| --- | --- |
+| `app/coverage-summary.txt` | Human-readable table, same content posted to the CI Job Summary |
+| `app/coverage.json` | Machine-readable summary; CI reads `.data[0].totals.lines.percent` for the threshold check |
+
+Both files are gitignored.
+
+## Requirement: `llvm-tools` Component
+
+`cargo-llvm-cov` needs the `llvm-tools` rustup component. Locally:
+
+```bash
+rustup component add llvm-tools-preview
+```
+
+CI installs it automatically via `actions-rust-lang/setup-rust-toolchain`'s `components: llvm-tools`.
+
+## CI Workflow
+
+`.github/workflows/coverage.yml` runs on `push` / `pull_request`, following the
+`paths` filter pattern used by `check-rust.yml` (`app/*/src/**`, not `app/src/**`).
+
+Steps:
+
+1. `mise run rs-coverage`
+2. Append `app/coverage-summary.txt` to the GitHub Actions Job Summary
+3. Read `app/coverage.json`'s line coverage percentage and emit `::warning::` if it is below 90%
+
+## Step-by-Step: Checking Coverage for a Change
+
+1. Run `mise run rs-coverage`
+2. Check the `TOTAL` row's `Lines` cover column in `app/coverage-summary.txt`
+3. Look at per-file rows to find uncovered code paths

--- a/mise.lock
+++ b/mise.lock
@@ -124,6 +124,10 @@ url = "https://github.com/betterleaks/betterleaks/releases/download/v1.6.1/bette
 url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/462264905"
 provenance = "cosign"
 
+[[tools."cargo:cargo-llvm-cov"]]
+version = "0.8.7"
+backend = "cargo:cargo-llvm-cov"
+
 [[tools.cspell]]
 version = "10.0.1"
 backend = "npm:cspell"

--- a/mise.toml
+++ b/mise.toml
@@ -20,6 +20,7 @@ atlas = "1.2.0"
 
 # Testing
 "github:k1LoW/runn" = "v1.9.4"
+"cargo:cargo-llvm-cov" = "0.8.7"
 
 # Markdown
 markdownlint-cli2 = "0.23.1"
@@ -141,6 +142,17 @@ run = [
   "cargo test -- --nocapture",
 ]
 alias = "rc"
+dir = "{{vars.app_dir}}"
+
+[tasks.rs-coverage]
+description = "Measure Rust test coverage"
+run = [
+  "cargo llvm-cov clean --workspace",
+  "cargo llvm-cov --workspace --all-features --no-report",
+  "cargo llvm-cov report > coverage-summary.txt",
+  "cat coverage-summary.txt",
+  "cargo llvm-cov report --json --summary-only --output-path coverage.json",
+]
 dir = "{{vars.app_dir}}"
 
 [tasks.rs-run]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Add test coverage measurement to CI using `cargo-llvm-cov`, per #81 (part of the tracking Issue #79).

## Reason for change

We currently have no visibility into test coverage. This introduces a report-only measurement: coverage is always shown in the Job Summary and never gates CI, keeping the addition low-risk while giving contributors a signal to act on.

## Changes

- Add `cargo-llvm-cov` to `mise.toml`'s `[tools]` (pinned `0.8.7`) and update `mise.lock`
- Add a new `rs-coverage` mise task: runs the workspace test suite under `cargo-llvm-cov`, writes a human-readable summary (`app/coverage-summary.txt`) and a machine-readable JSON summary (`app/coverage.json`)
- Add `.github/workflows/coverage.yml`: runs on `push`/`pull_request` (same `paths` filter pattern as `check-rust.yml`), posts the summary to the Job Summary, and emits `::warning::` when line coverage drops below 90% (never fails the job)
- Add `docs/workflows/COVERAGE.md` documenting the policy, local usage, and CI behavior
- Add `README.md` entry for `rs-coverage` and `.gitignore` entries for the generated coverage files

## Notes

- No PR comment integration and no external service (e.g. Codecov) — Job Summary only, per the tracking Issue's stated policy.
- No scheduled run; triggers match `check-rust.yml`'s `push`/`pull_request` pattern.