### PR TITLE
ci: Add mutation testing using cargo-mutants

### DIFF
--- a/.cspell/dicts/project.txt
+++ b/.cspell/dicts/project.txt
@@ -25,3 +25,4 @@ getrandom
 argon
 DOTALL
 rustflags
+unviable

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,100 @@
+name: Mutation Testing
+
+on:
+  pull_request:
+    paths:
+      - "app/*/src/**"
+      - "app/Cargo.toml"
+      - "app/Cargo.lock"
+      - "mise.toml"
+      - "mise.lock"
+      - ".github/workflows/mutation-testing.yml"
+  schedule:
+    - cron: "0 0 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  mutation-testing:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          rustflags: ""
+
+      - name: Install mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate diff against base branch
+        if: github.event_name == 'pull_request'
+        run: git -C app diff --relative "origin/${GITHUB_BASE_REF}"...HEAD > app/mutants.diff
+
+      - name: Run mutation testing (changed lines only)
+        if: github.event_name == 'pull_request'
+        run: mise run rs-mutants-diff || true
+
+      - name: Run mutation testing (full suite)
+        if: github.event_name == 'schedule'
+        run: mise run rs-mutants || true
+
+      - name: Publish mutation results to Job Summary
+        if: always()
+        run: |
+          if [ ! -f app/mutants.out/outcomes.json ]; then
+            echo "## Mutation Testing" >> "$GITHUB_STEP_SUMMARY"
+            echo "No mutants were tested (e.g. the diff touched no mutable lines)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Mutation Testing"
+            echo '```'
+            jq -r '"Total: \(.total_mutants)  Caught: \(.caught)  Missed: \(.missed)  Timeout: \(.timeout)  Unviable: \(.unviable)"' app/mutants.out/outcomes.json
+            echo '```'
+            if [ -s app/mutants.out/missed.txt ]; then
+              echo "### Surviving mutants"
+              echo '```'
+              cat app/mutants.out/missed.txt
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Warn on low mutation score
+        if: always()
+        run: |
+          if [ ! -f app/mutants.out/outcomes.json ]; then
+            echo "No outcomes.json; skipping threshold check"
+            exit 0
+          fi
+          caught=$(jq '.caught' app/mutants.out/outcomes.json)
+          missed=$(jq '.missed' app/mutants.out/outcomes.json)
+          tested=$((caught + missed))
+          if [ "${tested}" -eq 0 ]; then
+            echo "No mutants were caught or missed; skipping threshold check"
+            exit 0
+          fi
+          score=$(awk -v c="${caught}" -v t="${tested}" 'BEGIN { printf "%.2f", (c / t) * 100 }')
+          echo "Mutation score: ${score}%"
+          if awk -v s="${score}" 'BEGIN { exit !(s < 80) }'; then
+            echo "::warning::Mutation score ${score}% is below the 80% threshold"
+          fi

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -52,11 +52,23 @@ jobs:
 
       - name: Run mutation testing (changed lines only)
         if: github.event_name == 'pull_request'
-        run: mise run rs-mutants-diff || true
+        run: |
+          mise run rs-mutants-diff
+          code=$?
+          if [ "${code}" -ne 0 ] && [ "${code}" -ne 2 ]; then
+            echo "::warning::cargo-mutants exited with unexpected code ${code} (see logs above); results below may be incomplete"
+          fi
+          exit 0
 
       - name: Run mutation testing (full suite)
         if: github.event_name == 'schedule'
-        run: mise run rs-mutants || true
+        run: |
+          mise run rs-mutants
+          code=$?
+          if [ "${code}" -ne 0 ] && [ "${code}" -ne 2 ]; then
+            echo "::warning::cargo-mutants exited with unexpected code ${code} (see logs above); results below may be incomplete"
+          fi
+          exit 0
 
       - name: Publish mutation results to Job Summary
         if: always()

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -53,8 +53,11 @@ jobs:
       - name: Run mutation testing (changed lines only)
         if: github.event_name == 'pull_request'
         run: |
-          mise run rs-mutants-diff
-          code=$?
+          if mise run rs-mutants-diff; then
+            code=0
+          else
+            code=$?
+          fi
           if [ "${code}" -ne 0 ] && [ "${code}" -ne 2 ]; then
             echo "::warning::cargo-mutants exited with unexpected code ${code} (see logs above); results below may be incomplete"
           fi
@@ -63,8 +66,11 @@ jobs:
       - name: Run mutation testing (full suite)
         if: github.event_name == 'schedule'
         run: |
-          mise run rs-mutants
-          code=$?
+          if mise run rs-mutants; then
+            code=0
+          else
+            code=$?
+          fi
           if [ "${code}" -ne 0 ] && [ "${code}" -ne 2 ]; then
             echo "::warning::cargo-mutants exited with unexpected code ${code} (see logs above); results below may be incomplete"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 app/target/
 app/coverage.json
 app/coverage-summary.txt
+app/mutants.out*
+app/mutants.diff

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ mise run db-apply
 | `mise run rs-fix` | `mise run rf` | Fix Rust code (clippy + fmt) |
 | `mise run rs-check` | `mise run rc` | Check Rust code |
 | `mise run rs-coverage` | | Measure test coverage |
+| `mise run rs-mutants` | | Run mutation testing (full suite) |
+| `mise run rs-mutants-diff` | | Run mutation testing (changed lines only) |
 | `mise run rs-build` | | Build the application |
 | `mise run rs-build-release` | | Build in release mode |
 | `mise run rs-clean` | | Clean build artifacts |

--- a/docs/workflows/MUTATION-TESTING.md
+++ b/docs/workflows/MUTATION-TESTING.md
@@ -1,0 +1,83 @@
+# Mutation Testing Guideline
+
+This document explains how mutation testing is run and reported in this project.
+
+## Tooling
+
+- [`cargo-mutants`](https://mutants.rs/) introduces small code mutations (e.g. flipping
+  operators, changing return values) and checks whether the test suite catches them.
+  A surviving ("missed") mutant marks a gap that line coverage alone cannot reveal.
+- Pinned in `mise.toml`'s `[tools]`; installed via `mise install`.
+
+## Policy
+
+- Report only — mutation testing never fails CI.
+- Pull requests test only the mutants that overlap with changed lines
+  (`--in-diff`, diffed against the PR base branch); the daily schedule
+  (`0 0 * * *` UTC) tests the full suite.
+- Surviving mutants are always listed in the workflow's Job Summary.
+- `::warning::` is emitted when the mutation score drops below **80%**, on
+  either trigger.
+
+## Running Locally
+
+```bash
+mise run rs-mutants        # full suite
+mise run rs-mutants-diff   # only mutants overlapping app/mutants.diff
+```
+
+`rs-mutants-diff` expects a diff file at `app/mutants.diff`. Generate one against
+the default branch before running it:
+
+```bash
+git -C app diff --relative origin/main...HEAD > app/mutants.diff
+mise run rs-mutants-diff
+```
+
+`--relative` strips the `app/` prefix from the diff paths so they match the
+file paths `cargo-mutants` sees when it runs with `app/` as its working
+directory; a diff generated from the repository root (with an `app/`
+prefix) would not overlap with any mutant and silently test nothing.
+
+Both tasks write their results to `app/mutants.out/`:
+
+| File | Purpose |
+| --- | --- |
+| `outcomes.json` | Machine-readable summary; CI reads `.caught` and `.missed` for the score |
+| `missed.txt` | Names of mutants the test suite did not catch |
+| `caught.txt`, `timeout.txt`, `unviable.txt` | Other outcome categories |
+
+`app/mutants.out*` and `app/mutants.diff` are gitignored.
+
+## Mutation Score
+
+```text
+score = caught / (caught + missed) * 100
+```
+
+Mutants that fail to build (`unviable`) or time out (`timeout`) are excluded
+from the score, since they don't indicate a test gap.
+
+## CI Workflow
+
+`.github/workflows/mutation-testing.yml` runs on `pull_request` and on a daily
+`schedule`, following the `paths` filter pattern used by `check-rust.yml`
+(`app/*/src/**`, not `app/src/**`).
+
+Steps:
+
+1. On `pull_request`: diff against the base branch (`git diff
+   origin/$GITHUB_BASE_REF...HEAD -- app`) and run `mise run rs-mutants-diff`.
+   On `schedule`: run `mise run rs-mutants`.
+2. Append `app/mutants.out/outcomes.json`'s summary and `missed.txt`'s
+   contents to the GitHub Actions Job Summary.
+3. Compute the score from `outcomes.json` and emit `::warning::` if it is
+   below 80%.
+
+## Step-by-Step: Investigating a Missed Mutant
+
+1. Run `mise run rs-mutants` (or `rs-mutants-diff` for a quick, local check).
+2. Find the function and mutation in `app/mutants.out/missed.txt`.
+3. Add or strengthen a test that asserts the actual computed value, not just
+   that the call succeeds — this is what usually lets a mutant slip through.
+4. Re-run and confirm the mutant now appears in `caught.txt`.

--- a/docs/workflows/MUTATION-TESTING.md
+++ b/docs/workflows/MUTATION-TESTING.md
@@ -66,8 +66,8 @@ from the score, since they don't indicate a test gap.
 
 Steps:
 
-1. On `pull_request`: diff against the base branch (`git diff
-   origin/$GITHUB_BASE_REF...HEAD -- app`) and run `mise run rs-mutants-diff`.
+1. On `pull_request`: diff against the base branch (`git -C app diff --relative
+   origin/$GITHUB_BASE_REF...HEAD`) and run `mise run rs-mutants-diff`.
    On `schedule`: run `mise run rs-mutants`.
 2. Append `app/mutants.out/outcomes.json`'s summary and `missed.txt`'s
    contents to the GitHub Actions Job Summary.

--- a/mise.lock
+++ b/mise.lock
@@ -128,6 +128,10 @@ provenance = "cosign"
 version = "0.8.7"
 backend = "cargo:cargo-llvm-cov"
 
+[[tools."cargo:cargo-mutants"]]
+version = "27.1.0"
+backend = "cargo:cargo-mutants"
+
 [[tools.cspell]]
 version = "10.0.1"
 backend = "npm:cspell"

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,7 @@ atlas = "1.2.0"
 # Testing
 "github:k1LoW/runn" = "v1.9.4"
 "cargo:cargo-llvm-cov" = "0.8.7"
+"cargo:cargo-mutants" = "27.1.0"
 
 # Markdown
 markdownlint-cli2 = "0.23.1"
@@ -153,6 +154,16 @@ run = [
   "cat coverage-summary.txt",
   "cargo llvm-cov report --json --summary-only --output-path coverage.json",
 ]
+dir = "{{vars.app_dir}}"
+
+[tasks.rs-mutants]
+description = "Run mutation testing (full suite)"
+run = "cargo mutants --no-shuffle -vV"
+dir = "{{vars.app_dir}}"
+
+[tasks.rs-mutants-diff]
+description = "Run mutation testing (changed lines only, via --in-diff)"
+run = "cargo mutants --no-shuffle -vV --in-diff mutants.diff"
 dir = "{{vars.app_dir}}"
 
 [tasks.rs-run]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Adds mutation testing to the test-quality tooling started in #79 (sibling to
coverage measurement in #81), using [cargo-mutants](https://mutants.rs/).

## Reason for change

Line coverage tells you a line ran; it can't tell you whether a test would
notice if that line were wrong. Mutation testing closes that gap by
deliberately breaking the code and checking whether any test fails.

## Changes

- Two mise tasks: `rs-mutants` (full suite) and `rs-mutants-diff` (`--in-diff`)
- `cargo-mutants` pinned in `mise.toml`'s `[tools]`, `mise.lock` updated
- `.github/workflows/mutation-testing.yml`:
  - PR: diffs against the base branch (paths relative to `app/`, via
    `git -C app diff --relative`) and runs only the overlapping mutants
  - Daily schedule (`0 0 * * *` UTC): runs the full suite
  - Report only — never fails the job; `::warning::` when the score is
    below 80% on either trigger
  - Surviving mutants listed in the Job Summary
  - Distinguishes `cargo-mutants` exit code 2 (missed mutants, expected)
    from other nonzero codes (baseline failure, invalid diff, internal
    error), surfacing the latter as a `::warning::` instead of swallowing
    them silently
- `docs/workflows/MUTATION-TESTING.md`
- `README.md` updated with the two new task rows
- `.gitignore` / cspell dictionary updated for generated artifacts and
  cargo-mutants terminology

## Notes

Closes #82.