### PR TITLE
ci: Manage Rust with mise

### DIFF
--- a/.claude/rules/ci.md
+++ b/.claude/rules/ci.md
@@ -1,0 +1,12 @@
+---
+name: ci
+description: GitHub Actions workflow conventions for this repository
+paths: ".github/workflows/**"
+---
+
+# CI Workflows
+
+## Scope `jdx/mise-action` Installs
+
+- When a job only needs specific tools (e.g. only `rust` for a Rust-only check job), pass `install_args` to `jdx/mise-action` listing just those tools, instead of a bare `install: true`.
+- A bare `install: true` installs every tool declared in `mise.toml`'s `[tools]`, even ones the job never uses (e.g. `node`, `atlas`, `sqruff`, `cspell`) — wasted CI time with no benefit to that job.

--- a/.cspell/dicts/project.txt
+++ b/.cspell/dicts/project.txt
@@ -27,3 +27,4 @@ DOTALL
 rustflags
 unviable
 esac
+Swatinem

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -6,12 +6,16 @@ on:
       - "app/*/src/**"
       - "app/Cargo.toml"
       - "app/Cargo.lock"
+      - "mise.toml"
+      - "mise.lock"
       - ".github/workflows/check-rust.yml"
   pull_request:
     paths:
       - "app/*/src/**"
       - "app/Cargo.toml"
       - "app/Cargo.lock"
+      - "mise.toml"
+      - "mise.lock"
       - ".github/workflows/check-rust.yml"
 
 concurrency:
@@ -35,18 +39,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          components: rustfmt, clippy
-          rustflags: ""
-
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          install: false
+          install: true
+          install_args: "rust"
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: app
 
       - name: Fix
         run: mise run rs-fix

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,18 +39,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          components: llvm-tools
-          rustflags: ""
-
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           install: true
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: app
 
       - name: Measure coverage
         run: mise run rs-coverage

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,20 +51,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          rustflags: ""
-
       - name: Install mise and setup
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           install: true
-          install_args: "atlas github:k1LoW/runn"
+          install_args: "rust atlas github:k1LoW/runn"
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           MISE_LOCKED: "1"
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: app
 
       - name: Check
         run: mise run integration-test

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -34,17 +34,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
-        with:
-          rustflags: ""
-
       - name: Install mise
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           install: true
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: app
 
       - name: Generate diff against base branch
         if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ graph TB
 ### Pre-requirements
 
 - [mise](https://mise.jdx.dev)
-- [rustup](https://rustup.rs)
 - [Docker](https://www.docker.com) (with Compose)
 
 ### Setup

--- a/docs/workflows/COVERAGE.md
+++ b/docs/workflows/COVERAGE.md
@@ -32,13 +32,8 @@ Both files are gitignored.
 
 ## Requirement: `llvm-tools` Component
 
-`cargo-llvm-cov` needs the `llvm-tools` rustup component. Locally:
-
-```bash
-rustup component add llvm-tools
-```
-
-CI installs it automatically via `actions-rust-lang/setup-rust-toolchain`'s `components: llvm-tools`.
+`cargo-llvm-cov` needs the `llvm-tools` rustup component. It is declared in `mise.toml`'s
+`rust` tool `components`, so `mise install` provisions it both locally and in CI.
 
 ## CI Workflow
 

--- a/mise.lock
+++ b/mise.lock
@@ -310,6 +310,14 @@ url = "https://nodejs.org/dist/v26.3.0/node-v26.3.0-darwin-x64.tar.gz"
 checksum = "sha256:ec6d0f6b056c89498a9b26c4d5c77a31fd0b7fe45ba8a45fa87d26f66c3ebce4"
 url = "https://nodejs.org/dist/v26.3.0/node-v26.3.0-win-x64.zip"
 
+[[tools.rust]]
+version = "1.97.1"
+backend = "core:rust"
+
+[tools.rust.options]
+components = "clippy,llvm-tools,rustfmt"
+profile = "minimal"
+
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,9 @@ minimum_release_age = "3d"
 # Node.js
 node = "26"
 
+# Rust
+rust = { version = "1.97.1", profile = "minimal", components = "rustfmt,clippy,llvm-tools" }
+
 # Database
 atlas = "1.2.0"
 "github:quarylabs/sqruff" = "0.38"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Checklist

- [x] Target branch is `main`
- [x] Status checks are passing

## Summary

Puts the Rust toolchain under mise's control. `mise install` now provisions Rust for both local development and CI, replacing the standalone rustup / `actions-rust-lang/setup-rust-toolchain` path.

## Reason for change

mise already owns every other tool in this project (node, atlas, sqruff, cargo-llvm-cov, cargo-mutants, …). Rust was the lone exception, installed via rustup locally and via `actions-rust-lang/setup-rust-toolchain` in CI — a second source of truth for the toolchain version that Renovate's mise manager couldn't track. This was unblocked by #89 (fuzzing removal), which was the only reason mise couldn't own the whole toolchain (the nightly-only fuzz job needed a separate toolchain).

## Changes

- `mise.toml`: add `rust = "1.97.1"` (exact pin, matching the convention of other tools) with `profile = "minimal"` and `components = "rustfmt,clippy,llvm-tools"`.
- `mise.lock`: regenerated to include the `rust` tool entry.
- `.github/workflows/check-rust.yml`, `coverage.yml`, `mutation-testing.yml`, `integration-test.yml`: remove the `actions-rust-lang/setup-rust-toolchain` step; install Rust via mise instead; add a `Swatinem/rust-cache` step (pinned to a commit SHA) to preserve cargo build caching, since `mise-action`'s cache only covers mise-managed tools, not the cargo build cache `setup-rust-toolchain` used to bundle.
- `check-rust.yml`: also add `mise.toml`/`mise.lock` to the `paths` filter (the other three workflows already had them) and scope `install_args: "rust"` so the job only installs what it needs.
- `integration-test.yml`: extend `install_args` to include `rust` alongside `atlas` and `runn`.
- `README.md`: remove `rustup` from Pre-requirements.
- `docs/workflows/COVERAGE.md`: replace the rustup/setup-rust-toolchain llvm-tools instructions with the mise-based flow.
- `.cspell/dicts/project.txt`: add `Swatinem`.

## Notes

Closes #84. The repo previously had no pinned Rust version (CI ran `setup-rust-toolchain` without a `toolchain` input, always using the current latest stable); `1.97.1` was the latest stable at implementation time and is now the pinned baseline going forward, tracked by Renovate's mise manager.